### PR TITLE
Remove Canine Influenza from dog annual vaccination plan

### DIFF
--- a/py_vetlog_analyzer/dog_vaccination_strategy.py
+++ b/py_vetlog_analyzer/dog_vaccination_strategy.py
@@ -42,6 +42,5 @@ class DogVaccinationStrategy(VaccinationStrategy):
                 register_vaccination("Deworming")
                 register_vaccination("Leptospirosis")
                 register_vaccination("Rabies")
-                register_vaccination("Canine Influenza")
-                count = 5
+                count = 4
         return count

--- a/tests/test_dog_vaccination_strategy.py
+++ b/tests/test_dog_vaccination_strategy.py
@@ -35,7 +35,7 @@ class FixedTest(unittest.TestCase):
     def test_generate_annual_vaccination_records(self):
         six_months_ago = datetime.now() - timedelta(weeks=20, days=8)
         pet = [PET_ID, PET_NAME, six_months_ago, PET_TYPE]
-        self.assertEqual(context.vaccinate(pet), 5)
+        self.assertEqual(context.vaccinate(pet), 4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Removed Canine Influenza vaccine from the dog's annual vaccination plan to keep it as an optional vaccine rather than mandatory.

## Changes Made
- ✅ Removed "Canine Influenza" vaccination from dog_vaccination_strategy.py
- ✅ Updated test_dog_vaccination_strategy.py (changed expected count from 5 to 4)
- ✅ Code formatted with Black
- ✅ Dog vaccination tests passing

## Acceptance Criteria Met
- [x] "Canine Influenza" is no longer in the code
- [x] Tests updated accordingly
- [x] All relevant tests passing


Fixes #64 