### PR TITLE
Add deworming registration for weeks 0-5 Fixes #65

### DIFF
--- a/py_vetlog_analyzer/dog_vaccination_strategy.py
+++ b/py_vetlog_analyzer/dog_vaccination_strategy.py
@@ -22,6 +22,9 @@ class DogVaccinationStrategy(VaccinationStrategy):
             VaccinesGenerator(self.connection).register_vaccination(name, pet)
 
         match int(weeks):
+            case weeks if weeks in range(0, 6):
+                register_vaccination("Deworming")
+                count = 1
             case weeks if weeks in range(6, 10):
                 register_vaccination("DA2PP")
                 register_vaccination("Deworming")

--- a/tests/test_dog_vaccination_strategy.py
+++ b/tests/test_dog_vaccination_strategy.py
@@ -13,9 +13,9 @@ context = Context(DogVaccinationStrategy(MagicMock()))
 
 
 class FixedTest(unittest.TestCase):
-    def test_generate_no_vaccination_records(self):
+    def test_generate_early_vaccination_records(self):
         pet = [PET_ID, PET_NAME, datetime.now(), PET_TYPE]
-        self.assertEqual(context.vaccinate(pet), 0)
+        self.assertEqual(context.vaccinate(pet), 1)
 
     def test_generate_first_vaccination_records(self):
         two_months_ago = datetime.now() - timedelta(weeks=6, days=8)


### PR DESCRIPTION
## Description
Added deworming registration to the vaccination plan for puppies between weeks 0-5 to improve vaccination records for early-stage puppies.

## Changes Made
- ✅ Added new case for weeks 0-5 in dog_vaccination_strategy.py
- ✅ Updated test_dog_vaccination_strategy.py to reflect early week deworming
- ✅ Modified test case to expect 1 vaccination for young puppies
- ✅ Code formatted with Black
- ✅ Dog vaccination tests passing

## Acceptance Criteria Met
- [x] Deworming registration added for weeks 0-5
- [x] Test cases modified accordingly
- [x] All relevant tests passing


Fixes #65 