### PR TITLE
ci: pin full commit SHA hashes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: "3.12.3"
 
       - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true


### PR DESCRIPTION
This PR pins all GitHub Actions to exact commit SHAs to satisfy SonarCloud.

Fixes #82 