### PR TITLE
Add dewormings entry point and pet listing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 list_suspicious = "vetlog_buddy.main:list_suspicious_users"
 remove_invalid = "vetlog_buddy.main:remove_invalid_users"
 vaccines = "vetlog_buddy.main:vaccines"
+dewormings = "vetlog_buddy.main:dewormings"
 version = "vetlog_buddy.main:version_check"
 
 [build-system]

--- a/src/vetlog_buddy/dewormings/__init__.py
+++ b/src/vetlog_buddy/dewormings/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2026 Jose Morales contact@josdem.io
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License

--- a/src/vetlog_buddy/dewormings/model.py
+++ b/src/vetlog_buddy/dewormings/model.py
@@ -1,0 +1,18 @@
+#  Copyright 2026 Jose Morales contact@josdem.io
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License
+
+from vetlog_buddy.vaccinations.model import Vaccination
+
+# Deworming uses the same Vaccination model with name="Deworming"
+__all__ = ["Vaccination"]

--- a/src/vetlog_buddy/dewormings/repository.py
+++ b/src/vetlog_buddy/dewormings/repository.py
@@ -1,0 +1,50 @@
+#  Copyright 2026 Jose Morales contact@josdem.io
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License
+
+from datetime import datetime
+from typing import List, Tuple
+from sqlmodel import Session, text
+
+from vetlog_buddy.vaccinations.model import Vaccination, VaccineType
+
+
+class DewormingRepository:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def create(self, pet_id: int) -> Vaccination:
+        """Create a pending deworming vaccination record."""
+        vaccination = Vaccination(
+            pet_id=pet_id,
+            name=VaccineType.DEWORMING,
+            date=datetime.now(),
+            status="PENDING",
+        )
+        self.session.add(vaccination)
+        self.session.commit()
+        self.session.refresh(vaccination)
+        return vaccination
+
+    def get_pets_with_pending_deworming(self) -> List[Tuple]:
+        """Get pets that have a pending deworming record."""
+        stmt = text(
+            """SELECT pet.id, pet.name, pet.birth_date, breed.type 
+               FROM pet 
+               JOIN breed ON breed.id = pet.breed_id 
+               JOIN vaccination ON vaccination.pet_id = pet.id 
+               WHERE vaccination.status='PENDING' 
+               AND vaccination.name='Deworming'
+               GROUP BY pet.id"""
+        )
+        return self.session.exec(stmt).all()

--- a/src/vetlog_buddy/dewormings/services.py
+++ b/src/vetlog_buddy/dewormings/services.py
@@ -1,0 +1,27 @@
+#  Copyright 2026 Jose Morales contact@josdem.io
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License
+
+from vetlog_buddy.dewormings.repository import DewormingRepository
+from vetlog_buddy.shared.logger import Logger
+
+
+class DewormingService:
+    def __init__(self, repository: DewormingRepository):
+        self.repository = repository
+        self.logger = Logger("DewormingService")
+
+    def deworm_pet(self, pet_id: int, pet_name: str):
+        """Create a pending deworming record for a pet."""
+        self.logger.info("Creating deworming record for pet: %s", pet_name)
+        return self.repository.create(pet_id)

--- a/src/vetlog_buddy/main.py
+++ b/src/vetlog_buddy/main.py
@@ -19,6 +19,8 @@ from vetlog_buddy.pets.repository import PetRepository
 from vetlog_buddy.pets.services import PetService
 from vetlog_buddy.vaccinations.repository import VaccinationRepository
 from vetlog_buddy.vaccinations.services import VaccinationService
+from vetlog_buddy.dewormings.repository import DewormingRepository
+from vetlog_buddy.dewormings.services import DewormingService
 
 from . import __project__, __version__
 
@@ -46,6 +48,16 @@ def vaccines():
         vacc_service = VaccinationService(vacc_repo)
         pet_service = PetService(pet_repo, vacc_service)
         pet_service.process_vaccinations()
+
+
+def dewormings():
+    """List pets waiting for deworming and create records."""
+    with get_session() as session:
+        pet_repo = PetRepository(session)
+        deworm_repo = DewormingRepository(session)
+        deworm_service = DewormingService(deworm_repo)
+        pet_service = PetService(pet_repo, deworm_service=deworm_service)
+        pet_service.process_dewormings()
 
 
 def version_check():

--- a/src/vetlog_buddy/pets/repository.py
+++ b/src/vetlog_buddy/pets/repository.py
@@ -12,10 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License
 
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 from sqlmodel import Session, select, text
 
 from vetlog_buddy.pets.model import Pet, Breed
+from vetlog_buddy.vaccinations.model import VaccineType
 
 
 class PetRepository:
@@ -31,6 +32,46 @@ class PetRepository:
         # Original: SELECT pet.id, pet.name, pet.birth_date, breed.type FROM pet, vaccination, breed WHERE breed.id = pet.breed_id and vaccination.pet_id = pet.id and vaccination.status='PENDING' GROUP BY pet.id;
         stmt = text(
             "SELECT pet.id, pet.name, pet.birth_date, breed.type FROM pet JOIN breed ON breed.id = pet.breed_id JOIN vaccination ON vaccination.pet_id = pet.id WHERE vaccination.status='PENDING' GROUP BY pet.id"
+        )
+        return self.session.exec(stmt).all()
+
+    def get_pets_with_pending_deworming(self) -> List[Tuple]:
+        """Get pets that have a pending deworming record."""
+        stmt = text(
+            """SELECT pet.id, pet.name, pet.birth_date, breed.type 
+               FROM pet 
+               JOIN breed ON breed.id = pet.breed_id 
+               JOIN vaccination ON vaccination.pet_id = pet.id 
+               WHERE vaccination.status='PENDING' 
+               AND vaccination.name='Deworming'
+               GROUP BY pet.id"""
+        )
+        return self.session.exec(stmt).all()
+
+    def get_pets_needing_deworming(self) -> List[Tuple]:
+        """Get pets whose last deworming was >= 1 year ago or have no deworming record.
+        
+        Returns pets that need a new deworming vaccination record.
+        """
+        stmt = text(
+            """SELECT p.id, p.name, p.birth_date, b.type
+               FROM pet p
+               JOIN breed b ON b.id = p.breed_id
+               WHERE p.id NOT IN (
+                   SELECT DISTINCT pet_id FROM vaccination 
+                   WHERE name = 'Deworming' AND status = 'PENDING'
+               )
+               AND (
+                   NOT EXISTS (
+                       SELECT 1 FROM vaccination v 
+                       WHERE v.pet_id = p.id AND v.name = 'Deworming'
+                   )
+                   OR EXISTS (
+                       SELECT 1 FROM vaccination v 
+                       WHERE v.pet_id = p.id AND v.name = 'Deworming'
+                       AND v.date <= DATE_SUB(CURDATE(), INTERVAL 1 YEAR)
+                   )
+               )"""
         )
         return self.session.exec(stmt).all()
 

--- a/src/vetlog_buddy/pets/services.py
+++ b/src/vetlog_buddy/pets/services.py
@@ -15,14 +15,19 @@
 from vetlog_buddy.pets.repository import PetRepository
 from vetlog_buddy.shared.logger import Logger
 from vetlog_buddy.vaccinations.services import VaccinationService
+from typing import Optional
 
 
 class PetService:
     def __init__(
-        self, repository: PetRepository, vaccination_service: VaccinationService
+        self,
+        repository: PetRepository,
+        vaccination_service: Optional[VaccinationService] = None,
+        deworm_service=None,
     ):
         self.repository = repository
         self.vaccination_service = vaccination_service
+        self.deworm_service = deworm_service
         self.logger = Logger("PetService")
 
     def process_vaccinations(self):
@@ -66,3 +71,34 @@ class PetService:
             "Pets waiting for vaccines found: %s", len(pets_waiting_for_vaccines)
         )
         return pets_waiting_for_vaccines
+
+    def process_dewormings(self):
+        """
+        Processes all pets that need deworming by creating pending deworming records.
+
+        This method:
+          - Retrieves all pets with pending deworming (to avoid duplicates).
+          - Retrieves all pets needing deworming (last deworming >= 1 year ago or none).
+          - Creates a pending deworming record for each.
+
+        Returns:
+            list: A list of pets (tuples) that were found waiting for deworming.
+        """
+        # Get pets that already have pending deworming (to skip)
+        pets_with_pending = self.repository.get_pets_with_pending_deworming()
+        self.logger.info("Pets with pending deworming: %s", len(pets_with_pending))
+
+        # Get pets that need deworming
+        pets_needing_deworming = self.repository.get_pets_needing_deworming()
+        self.logger.info("Pets needing deworming found: %s", len(pets_needing_deworming))
+
+        if not self.deworm_service:
+            self.logger.info("No deworming service configured")
+            return pets_needing_deworming
+
+        for row in pets_needing_deworming:
+            pet_id = row[0]
+            name = row[1]
+            self.deworm_service.deworm_pet(pet_id, name)
+
+        return pets_needing_deworming

--- a/tests/unit/test_deworming_service.py
+++ b/tests/unit/test_deworming_service.py
@@ -1,0 +1,55 @@
+import pytest
+from unittest.mock import MagicMock
+from datetime import datetime
+
+from vetlog_buddy.pets.services import PetService
+
+
+@pytest.fixture
+def mock_repo():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_deworm_service():
+    return MagicMock()
+
+
+@pytest.fixture
+def pet_service(mock_repo, mock_deworm_service):
+    return PetService(mock_repo, deworm_service=mock_deworm_service)
+
+
+def test_process_dewormings(pet_service, mock_repo, mock_deworm_service):
+    """Test that pets needing deworming get deworming records created."""
+    # Setup
+    pet_a = (1, "Rex", datetime.now(), "DOG")
+    pet_b = (2, "Felix", datetime.now(), "CAT")
+
+    # Pets already with pending deworming (should be skipped)
+    mock_repo.get_pets_with_pending_deworming.return_value = [pet_a]
+
+    # Pets needing deworming
+    mock_repo.get_pets_needing_deworming.return_value = [pet_b]
+
+    # Execute
+    result = pet_service.process_dewormings()
+
+    # Verify
+    assert len(result) == 1
+    assert result[0] == pet_b
+
+    # Verify deworm service called for pet_b only
+    mock_deworm_service.deworm_pet.assert_called_once_with(2, "Felix")
+
+
+def test_process_dewormings_no_service(pet_service, mock_repo):
+    """Test that without deworm service, pets are returned but no records created."""
+    pet_a = (1, "Rex", datetime.now(), "DOG")
+
+    mock_repo.get_pets_with_pending_deworming.return_value = []
+    mock_repo.get_pets_needing_deworming.return_value = [pet_a]
+
+    result = pet_service.process_dewormings()
+
+    assert len(result) == 1


### PR DESCRIPTION
Implements #134 and #138

## Changes

### New dewormings module
- `dewormings/model.py` - Reuses Vaccination model with VaccineType.DEWORMING
- `dewormings/repository.py` - DewormingRepository with create() and get_pets_with_pending_deworming()
- `dewormings/services.py` - DewormingService to create pending deworming records

### Entry point
- Added `dewormings()` function in main.py
- Registered `dewormings` CLI command in pyproject.toml

### PetRepository enhancements
- `get_pets_with_pending_deworming()` - Query pets with pending deworming status
- `get_pets_needing_deworming()` - Query pets whose last deworming was >= 1 year ago or have no deworming record

### PetService enhancement
- `process_dewormings()` - Find pets needing deworming and create records

### Tests
- Added unit tests in test_deworming_service.py

## Usage

```bash
dewormings  # CLI command to process pets needing deworming
```

## Implementation notes

- Deworming uses the existing Vaccination model with name="Deworming" (as defined in VaccineType)
- Logic mirrors the vaccines entry point pattern
- Pets with pending deworming are skipped to avoid duplicate records