### PR TITLE
feat: delete applied dewormings before creating new record

### DIFF
--- a/src/vetlog_buddy/vaccinations/repository.py
+++ b/src/vetlog_buddy/vaccinations/repository.py
@@ -40,3 +40,16 @@ class VaccinationRepository:
             & (Vaccination.date <= datetime.now() - timedelta(days=30 * months))
         )
         return self.session.exec(stmt).all()
+    
+    def delete_applied_dewormings(self):
+      stmt = select(Vaccination).where(
+        (Vaccination.status == "APPLIED")
+        & (Vaccination.name == VaccineType.DEWORMING)
+      )
+
+      vaccinations = self.session.exec(stmt).all()
+
+      for vaccination in vaccinations:
+        self.session.delete(vaccination)
+
+      self.session.commit()

--- a/src/vetlog_buddy/vaccinations/services.py
+++ b/src/vetlog_buddy/vaccinations/services.py
@@ -62,7 +62,7 @@ class VaccinationService:
         return self.repository.find_pending_dewormings(months)
 
     def create_deworming(self, pet: Pet):
-     """Create a deworming record for a pet"""
-     if pet.status not in EXCLUDED_STATUSES:
-        self.repository.delete_applied_dewormings()
-        self.repository.create(pet.id, VaccineType.DEWORMING)
+        """Create a deworming record for a pet"""
+        if pet.status not in EXCLUDED_STATUSES:
+            self.repository.delete_applied_dewormings()
+            self.repository.create(pet.id, VaccineType.DEWORMING)

--- a/src/vetlog_buddy/vaccinations/services.py
+++ b/src/vetlog_buddy/vaccinations/services.py
@@ -62,6 +62,7 @@ class VaccinationService:
         return self.repository.find_pending_dewormings(months)
 
     def create_deworming(self, pet: Pet):
-        """Create a deworming record for a pet"""
-        if pet.status not in EXCLUDED_STATUSES:
-            self.repository.create(pet.id, VaccineType.DEWORMING)
+     """Create a deworming record for a pet"""
+     if pet.status not in EXCLUDED_STATUSES:
+        self.repository.delete_applied_dewormings()
+        self.repository.create(pet.id, VaccineType.DEWORMING)

--- a/tests/unit/test_vaccination_repository.py
+++ b/tests/unit/test_vaccination_repository.py
@@ -78,3 +78,22 @@ def test_create_deworming():
     assert added_vaccination.pet_id == pet_id
     assert added_vaccination.name == vaccine_name
     assert added_vaccination.status == "NEW"
+def test_delete_applied_dewormings():
+    session = MagicMock(spec=Session)
+    repository = VaccinationRepository(session)
+
+    vaccination = Vaccination(
+        id=1,
+        pet_id=1,
+        name="Deworming",
+        date=datetime.now(),
+        status="APPLIED",
+    )
+
+    session.exec.return_value.all.return_value = [vaccination]
+
+    repository.delete_applied_dewormings()
+
+    session.exec.assert_called_once()
+    session.delete.assert_called_once_with(vaccination)
+    session.commit.assert_called_once()


### PR DESCRIPTION
## Description

This PR deletes all deworming records with status `APPLIED` before creating a new deworming record.

### Changes

* Added `delete_applied_dewormings()` method in `VaccinationRepository`
* Updated `create_deworming()` in `VaccinationService`
* Added unit test for applied deworming deletion logic

### Testing

* Ran unit tests successfully (`48 passed`)

Closes #149
