### PR TITLE
fix: log user service messages

### DIFF
--- a/src/vetlog_buddy/users/services.py
+++ b/src/vetlog_buddy/users/services.py
@@ -1,11 +1,13 @@
 from vetlog_buddy.users.repository import UserRepository
 from vetlog_buddy.users.model import User
+from vetlog_buddy.shared.logger import Logger
 
 
 class UserService:
     def __init__(self, repo: UserRepository, factor: float = 0.5) -> None:
         self.repo = repo
         self.factor = factor
+        self.logger = Logger("UserService")
 
     def is_invalid(self, user) -> bool:
         """Check if user is invalid using logic from filter_username"""
@@ -31,7 +33,7 @@ class UserService:
         for user in invalid_users:
             self.repo.delete(user)
             count += 1
-        print(f"Removed {count} invalid users")
+        self.logger.info("Removed %d invalid users", count)
         return count
 
     def is_suspicious(self, user) -> bool:
@@ -43,11 +45,11 @@ class UserService:
         all_users = self.repo.get_all()
         suspicious_users = [u for u in all_users if self.is_suspicious(u)]
         for user in suspicious_users:
-            print(
+            self.logger.info(
                 f"Suspicious user: {user.username} (min_ratio: {0.2}, max_ratio: {self.factor}, actual_ratio: {self.get_uppercase_ratio(user.username)})"
             )
         count = len(suspicious_users)
-        print(f"Found {count} suspicious users")
+        self.logger.info("Found %d suspicious users", count)
         return suspicious_users
 
     def get_uppercase_ratio(self, username: str) -> float:

--- a/tests/unit/test_user_service.py
+++ b/tests/unit/test_user_service.py
@@ -96,3 +96,37 @@ def test_get_by_id():
     result = service.get_by_id(1)
     assert result == user
     mock_repo.find_by_id.assert_called_once_with(1)
+
+
+def test_remove_invalid_logs_removed_count():
+    """Remove invalid users and log the removed count"""
+    mock_repo = MagicMock()
+    invalid_user = User(username="Max")
+    valid_user = User(username="josdem")
+    mock_repo.get_all.return_value = [invalid_user, valid_user]
+    service = UserService(repo=mock_repo)
+    service.logger = MagicMock()
+
+    result = service.remove_invalid()
+
+    assert result == 1
+    mock_repo.delete.assert_called_once_with(invalid_user)
+    service.logger.info.assert_called_once_with("Removed %d invalid users", 1)
+
+
+def test_list_suspicious_logs_each_user_and_total():
+    """List suspicious users and log detail plus total count"""
+    mock_repo = MagicMock()
+    suspicious_user = User(username="PvbGzTHuyk")
+    normal_user = User(username="josdem")
+    mock_repo.get_all.return_value = [suspicious_user, normal_user]
+    service = UserService(repo=mock_repo)
+    service.logger = MagicMock()
+
+    result = service.list_suspicious()
+
+    assert result == [suspicious_user]
+    service.logger.info.assert_any_call(
+        "Suspicious user: PvbGzTHuyk (min_ratio: 0.2, max_ratio: 0.5, actual_ratio: 0.4)"
+    )
+    service.logger.info.assert_any_call("Found %d suspicious users", 1)

--- a/tests/unit/test_user_service.py
+++ b/tests/unit/test_user_service.py
@@ -100,18 +100,23 @@ def test_get_by_id():
 
 def test_remove_invalid_logs_removed_count():
     """Remove invalid users and log the removed count"""
+    from unittest.mock import patch
+
     mock_repo = MagicMock()
     invalid_user = User(username="Max")
     valid_user = User(username="josdem")
     mock_repo.get_all.return_value = [invalid_user, valid_user]
-    service = UserService(repo=mock_repo)
-    service.logger = MagicMock()
 
-    result = service.remove_invalid()
+    logger_mock = MagicMock()
+    with patch("vetlog_buddy.users.services.Logger", return_value=logger_mock) as LoggerCls:
+        service = UserService(repo=mock_repo)
+        LoggerCls.assert_called_once_with("UserService")
+
+        result = service.remove_invalid()
 
     assert result == 1
     mock_repo.delete.assert_called_once_with(invalid_user)
-    service.logger.info.assert_called_once_with("Removed %d invalid users", 1)
+    logger_mock.info.assert_called_once_with("Removed %d invalid users", 1)
 
 
 def test_list_suspicious_logs_each_user_and_total():


### PR DESCRIPTION
## Summary

- replace `print` calls in `UserService` with the shared `Logger` wrapper
- add unit tests covering the new logging behavior for invalid and suspicious user flows

Fixes #174

## Root Cause

`UserService` emitted operational messages with `print`, unlike other services such as `VaccinationService`, so those messages did not include the configured timestamp/name/level logging format.

## Changes Made

- added `Logger("UserService")` to `UserService`
- changed removed-user and suspicious-user messages to `logger.info(...)`
- added tests that assert the service logs the removed count and suspicious-user summary while preserving existing return/delete behavior

## Testing

- `.venv/bin/python -m pytest tests/unit/test_user_service.py -q` — 21 passed
- `.venv/bin/python -m ruff check src/vetlog_buddy/users/services.py tests/unit/test_user_service.py`
- `git diff --check`
