### PR TITLE
Filter inactive pets from pending dewormings

### DIFF
--- a/src/vetlog_buddy/vaccinations/services.py
+++ b/src/vetlog_buddy/vaccinations/services.py
@@ -77,10 +77,14 @@ class VaccinationService:
 
     def get_pending_dewormings(self, months: int):
         """Return pending dewormings"""
-        return self.repository.find_pending_dewormings(months)
+        return [
+            deworming
+            for deworming in self.repository.find_pending_dewormings(months)
+            if (pet := self.pet_repository.find_by_id(deworming.pet_id)) is not None
+            and pet.status not in EXCLUDED_STATUSES
+        ]
 
     def create_deworming(self, pet: Pet):
         """Create a deworming record for a pet"""
-        if pet.status not in EXCLUDED_STATUSES:
-            self.repository.delete_applied_dewormings(pet.id)
-            self.repository.create(pet.id, VaccineType.DEWORMING, VaccineStatus.NEW)
+        self.repository.delete_applied_dewormings(pet.id)
+        self.repository.create(pet.id, VaccineType.DEWORMING, VaccineStatus.NEW)

--- a/tests/unit/test_vaccination_service.py
+++ b/tests/unit/test_vaccination_service.py
@@ -49,8 +49,69 @@ def test_get_pending_dewormings(service, mock_repo):
         )
     ]
     mock_repo.find_pending_dewormings.return_value = dewormings
+    service.pet_repository.find_by_id.return_value = Pet(
+        id=2,
+        name="Buddy",
+        birth_date=datetime(2020, 1, 1),
+        status="ACTIVE",
+    )
     assert service.get_pending_dewormings(12) == dewormings
     mock_repo.find_pending_dewormings.assert_called_once_with(12)
+    service.pet_repository.find_by_id.assert_called_once_with(2)
+
+
+def test_get_pending_dewormings_excludes_inactive_and_deceased_pets(
+    service, mock_repo, mock_pet_repo
+):
+    """Exclude inactive and deceased pets from pending deworming results"""
+    active_deworming = Vaccination(
+        id=1,
+        name="Deworming",
+        date=datetime(2025, 4, 21),
+        pet_id=1,
+        status="APPLIED",
+    )
+    inactive_deworming = Vaccination(
+        id=2,
+        name="Deworming",
+        date=datetime(2025, 4, 21),
+        pet_id=2,
+        status="APPLIED",
+    )
+    deceased_deworming = Vaccination(
+        id=3,
+        name="Deworming",
+        date=datetime(2025, 4, 21),
+        pet_id=3,
+        status="APPLIED",
+    )
+    mock_repo.find_pending_dewormings.return_value = [
+        active_deworming,
+        inactive_deworming,
+        deceased_deworming,
+    ]
+    mock_pet_repo.find_by_id.side_effect = [
+        Pet(
+            id=1,
+            name="Buddy",
+            birth_date=datetime(2020, 1, 1),
+            status="ACTIVE",
+        ),
+        Pet(
+            id=2,
+            name="Whiskers",
+            birth_date=datetime(2019, 6, 1),
+            status="INACTIVE",
+        ),
+        Pet(
+            id=3,
+            name="Shadow",
+            birth_date=datetime(2018, 3, 15),
+            status="DECEASED",
+        ),
+    ]
+
+    assert service.get_pending_dewormings(12) == [active_deworming]
 
 
 def test_create_deworming(service, mock_repo):
@@ -66,8 +127,8 @@ def test_create_deworming(service, mock_repo):
     mock_repo.create.assert_called_once_with(pet.id, "Deworming", VaccineStatus.NEW)
 
 
-def test_should_not_create_deworming_for_inactive_pet(service, mock_repo):
-    """Do not create a deworming record for an inactive pet"""
+def test_create_deworming_for_inactive_pet(service, mock_repo):
+    """Create a deworming record once an inactive pet reaches the method"""
     pet = Pet(
         id=3,
         name="Whiskers",
@@ -75,11 +136,12 @@ def test_should_not_create_deworming_for_inactive_pet(service, mock_repo):
         status="INACTIVE",
     )
     service.create_deworming(pet)
-    mock_repo.create.assert_not_called()
+    mock_repo.delete_applied_dewormings.assert_called_once_with(pet.id)
+    mock_repo.create.assert_called_once_with(pet.id, "Deworming", VaccineStatus.NEW)
 
 
-def test_should_not_create_deworming_for_deceased_pet(service, mock_repo):
-    """Do not create a deworming record for a deceased pet"""
+def test_create_deworming_for_deceased_pet(service, mock_repo):
+    """Create a deworming record once a deceased pet reaches the method"""
     pet = Pet(
         id=4,
         name="Shadow",
@@ -87,7 +149,8 @@ def test_should_not_create_deworming_for_deceased_pet(service, mock_repo):
         status="DECEASED",
     )
     service.create_deworming(pet)
-    mock_repo.create.assert_not_called()
+    mock_repo.delete_applied_dewormings.assert_called_once_with(pet.id)
+    mock_repo.create.assert_called_once_with(pet.id, "Deworming", VaccineStatus.NEW)
 
 
 def test_create_vaccination_for_dog(service, mock_repo, mock_pet_repo):


### PR DESCRIPTION
## Summary
- filter inactive and deceased pets from `get_pending_dewormings`
- remove the status gate from `create_deworming` so filtering happens before creation
- update service tests for active, inactive, and deceased pet deworming behavior

Closes #179.

## Verification
- `.\.venv\Scripts\python.exe -m pytest tests\unit\test_vaccination_service.py -q`
- `.\.venv\Scripts\python.exe -m pytest tests\unit -q`
- `.\.venv\Scripts\python.exe -m ruff check src\vetlog_buddy\vaccinations\services.py tests\unit\test_vaccination_service.py`
- `.\.venv\Scripts\python.exe -m ruff format --check src\vetlog_buddy\vaccinations\services.py tests\unit\test_vaccination_service.py`
- `git diff --check`